### PR TITLE
Added an authors array to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,12 @@
 	"type": "silverstripe-module",
 	"keywords": ["silverstripe", "segment"],
 	"license": "MIT",
+	"authors": [
+		{
+			"name": "Christopher Pitt",
+			"email": "cgpitt@gmail.com"
+		}
+	],
 	"require": {
 		"silverstripe/framework": "^3.1",
 		"silverstripe/cms": "^3.1"


### PR DESCRIPTION
Hey there @assertchris , I'm currently working for a company that has its own private composer repository. We use the system to keep our proprietary packages away from the public but we still use public packages so that we don't reinvent the wheel. To make a long story short, we would like to use your package in our private repository, but in order to do that we require the composer file to contain an authors array.  We do this in an effort to give credit to the original author. Please accept this pull request or add an authors array to the composer.json file manually.

Thanks in advance,
Mooror