### PR TITLE
Remove PHP 5.5 from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1


### PR DESCRIPTION
Reference: https://github.com/silverstripe/silverstripe-framework/issues/6705