### PR TITLE
FIX Remove autoload-dev, doesn't affect non-root projects, fix source folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"SilverStripe\\Forms\\": "code"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
+			"SilverStripe\\Forms\\": "src",
 			"SilverStripe\\Forms\\Tests\\": "tests"
 		}
 	}


### PR DESCRIPTION
Source folder is "src" not "code", and the `autoload-dev` is not relevant for modules.