### PR TITLE
Add support for help text

### DIFF
--- a/src/SegmentField.php
+++ b/src/SegmentField.php
@@ -31,6 +31,11 @@ class SegmentField extends TextField
     protected $preview = '';
 
     /**
+     * @var string
+     */
+    protected $helpText;
+
+    /**
      * @param array $modifiers
      *
      * @return $this
@@ -145,5 +150,23 @@ class SegmentField extends TextField
         }
 
         return $this;
+    }
+
+    /**
+     * @param string $string The secondary text to show
+     * @return $this
+     */
+    public function setHelpText($string)
+    {
+        $this->helpText = $string;
+        return $this;
+    }
+
+    /**
+     * @return string the secondary text to show in the template
+     */
+    public function getHelpText()
+    {
+        return $this->helpText;
     }
 }

--- a/templates/SilverStripe/Forms/SegmentField.ss
+++ b/templates/SilverStripe/Forms/SegmentField.ss
@@ -14,5 +14,5 @@
     <button class="cancel btn btn-secondary btn-sm">
         <%t SegmentField.Cancel 'Cancel' %>
     </button>
-    <% if $HelpText %><p class="help">$HelpText</p><% end_if %>
+    <% if $HelpText %><p class="help form__field-description">$HelpText</p><% end_if %>
 </div>


### PR DESCRIPTION
This is a quick little addition for support of the help text. I see it's in the template, and I'm assuming that's from duplicating the `SiteTreeURLSegmentField` approach, but it was missed being added in the code too. Adding support for it as I do find it useful being able to include some text only when the user is trying to change the URL segment (in my case with a warning that changing it will break existing links).

I also added the same class to the help text `p` element that the `SiteTreeURLSegmentField` uses in the admin. Not sure if that's acceptable or not.