### PR TITLE
Update classes to be PSR-4 compliant

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/tests            export-ignore
+/client/src       export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.github          export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 vendor
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     },
     "autoload": {
         "psr-4": {
-            "SilverStripe\\Forms\\": "code/",
-            "SilverStripe\\Forms\\Tests\\": "tests/"
+            "SilverStripe\\Forms\\": "src/",
+            "SilverStripe\\Forms\\Tests\\": "tests/" 
         }
     },
     "minimum-stability": "dev",

--- a/tests/SegmentFieldModifier/IDSegmentFieldModifierTest.php
+++ b/tests/SegmentFieldModifier/IDSegmentFieldModifierTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Forms\Tests;
+namespace SilverStripe\Forms\Tests\SegmentFieldModifier;
 
 use stdClass;
 use SilverStripe\Dev\SapphireTest;

--- a/tests/SegmentFieldModifier/SlugSegmentFieldModifierTest.php
+++ b/tests/SegmentFieldModifier/SlugSegmentFieldModifierTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Forms\Tests;
+namespace SilverStripe\Forms\Tests\SegmentFieldModifier;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;

--- a/tests/SegmentFieldTest.php
+++ b/tests/SegmentFieldTest.php
@@ -6,7 +6,6 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\SegmentField;
-use SilverStripe\Forms\SegmentFieldModifier\AbstractSegmentFieldModifier;
 
 class SegmentFieldTest extends SapphireTest
 {


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

- Update `autoload` configuration in `composer.json`
- Update namespacing for classes in `tests/SegmentFieldModifier`
- Add .gitattributes file

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #103 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
