### PR TITLE
MNT Add dev version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3",
+        "silverstripe/framework": "^4.10",
         "silverstripe/reports": "^4",
         "silverstripe/siteconfig": "^4"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Required to use phpunit 9.5 for --prefer-lowest build

https://github.com/silverstripe/silverstripe-segment-field/actions/runs/9851672224